### PR TITLE
Clarify ffmpeg build configure flag

### DIFF
--- a/docs/apps/ffmpeg.md
+++ b/docs/apps/ffmpeg.md
@@ -1,6 +1,6 @@
 # FFmpeg
 
-FFmpeg supports SRT protocol out of the box. But it needs to be built with `-enable-protocol=libsrt` to include SRT.
+FFmpeg supports SRT protocol out of the box. But it needs to be built with the configure flag `--enable-libsrt` to include SRT.
 
 Refer to [FFmpeg's Compilation Guide](https://trac.ffmpeg.org/wiki/CompilationGuide) for build instructions for your platform.
 


### PR DESCRIPTION
I've been able to build ffmpeg with SRT support using `./configure --enable-libsrt`, this change clarifies that ability. ISTM that this is the expected workflow for tweaking features for ffmpeg builds.

I may have just misunderstood  "[ffmpeg] needs to be built with `-enable-protocol=libsrt`...", if there's some distinction between a build flag and a configure flag.