### PR TITLE
New section with streaming apps, link for Play Pro for Android

### DIFF
--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -15,10 +15,14 @@ SRT is used by [thousands of organizations](https://www.srtalliance.org/members/
 * TSDuck [[Website]](https://tsduck.io/) [[GitHub]](https://github.com/tsduck/tsduck) [[Configuration Tips]](tsduck.md)
 
 ## Free of Charge Players with SRT support
-
 * VLC Media Player [[Website]](https://www.videolan.org/vlc/index.html) [[Configuration Tips]](https://srtlab.github.io/srt-cookbook/apps/vlc-media-player/)
 * FFPlay [[Website]](http://ffmpeg.org/ffplay.html) [[Configuration Tips (FFMpeg)]](https://srtlab.github.io/srt-cookbook/apps/ffmpeg/)
 * MPV [[Website](https://github.com/mpv-player/mpv)] [[PR submitted]](https://github.com/mpv-player/mpv/pull/8139)
-* Haivision Play Pro [[App Store](https://apps.apple.com/de/app/haivision-play-pro/id1482925169?l=en)] Will be available for Android soon!
-* Haivision Play [[App Store](https://apps.apple.com/de/app/haivision-play/id1054025311?l=en)] [[Google Play](https://play.google.com/store/apps/details?id=com.haivision.play)]
-* Larix Player [[App Store](https://apps.apple.com/de/app/larix-player/id1238237026?l=en)] [[Google Play](https://play.google.com/store/apps/details?id=com.softvelum.sldp_player)]
+* Haivision Play Pro [[AppStore](https://apps.apple.com/de/app/haivision-play-pro/id1482925169?l=en)] [[Google Play](https://play.google.com/store/apps/details?id=com.haivision.PlayPro)]
+* Haivision Play [[AppStore](https://apps.apple.com/de/app/haivision-play/id1054025311?l=en)] [[Google Play](https://play.google.com/store/apps/details?id=com.haivision.play)]
+* Larix Player [[AppStore](https://apps.apple.com/de/app/larix-player/id1238237026?l=en)] [[Google Play](https://play.google.com/store/apps/details?id=com.softvelum.sldp_player)]
+
+## Free of Charge Mobile Streaming Apps with SRT support
+* Haivision Play Pro [[AppStore](https://apps.apple.com/de/app/haivision-play-pro/id1482925169?l=en)] [[Google Play](https://play.google.com/store/apps/details?id=com.haivision.PlayPro)]
+* Larix Broadcaster [[AppStore](https://apps.apple.com/us/app/larix-broadcaster/id1042474385)] [[Google Play](https://play.google.com/store/apps/details?id=com.wmspanel.larix_broadcaster)]
+* Larix Screencaster [[AppStore](https://apps.apple.com/us/app/larix-screencaster/id1477313005)] [[Google Play](https://play.google.com/store/apps/details?id=com.wmspanel.larix_screencaster)]


### PR DESCRIPTION
Haivision Play Pro has its Android version now. Also added a new section populated by Larix apps and Play Pro.